### PR TITLE
Use onPageContentRaw instead of onPageContentProcessed hook

### DIFF
--- a/shortcode-core.php
+++ b/shortcode-core.php
@@ -42,7 +42,7 @@ class ShortcodeCorePlugin extends Plugin
         $this->enable([
             'onMarkdownInitialized' => ['onMarkdownInitialized', 0],
             'onShortcodeHandlers' => ['onShortcodeHandlers', 0],
-            'onPageContentProcessed' => ['onPageContentProcessed', 0],
+            'onPageContentRaw' => ['onPageContentRaw', 0],
             'onPageInitialized' => ['onPageInitialized', 0],
             'onTwigPageVariables' => ['onTwigPageVariables', 0],
             'onTwigSiteVariables' => ['onTwigSiteVariables', 0],
@@ -69,7 +69,7 @@ class ShortcodeCorePlugin extends Plugin
      *
      * @param Event $e
      */
-    public function onPageContentProcessed(Event $e)
+    public function onPageContentRaw(Event $e)
     {
         /** @var Page $page */
         $page = $e['page'];


### PR DESCRIPTION
Use onPageContentRaw instead of onPageContentProcessed hook to avoid getting the shortcode output wrapped in a paragraph tag.

In the current version, when you use the [center]text[/center] block shortcode, the output is

  `<p><div style="text-align: center;">text</div></p>`

To avoid that extra p tag, I used the onPageContentRaw hook which will inject markup before markdown is processed.
