### PR TITLE
Added FigureShortcode "figure"

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,13 @@ You can also specifically choose from `note`, `info`, `warning`, `tip` types whi
 Danger Will Robinson! Danger, Will Robinson!
 [/notice]
 ```
+#### Figure
+
+Figure elements are the recommended way to add self-contained units of flow content, i.e. images, charts and other visual elements that can be moved away from the main flow of the document without affecting the document's meaning. Figures may include captions through the `caption` attribute. Both `id` and `class` attributes are also available.
+
+[figure id="fig1" class="image" caption="**Fig. 1** A beautiful figure."]
+![Gorgeous image](image.png)
+[/figure]
 
 #### FontAwesome
 

--- a/shortcodes/FigureShortcode.php
+++ b/shortcodes/FigureShortcode.php
@@ -1,0 +1,21 @@
+<?php
+namespace Grav\Plugin\Shortcodes;
+
+use Thunder\Shortcode\Shortcode\ShortcodeInterface;
+
+class FigureShortcode extends Shortcode
+{
+    public function init()
+    {
+        $this->shortcode->getHandlers()->add('figure', function(ShortcodeInterface $sc) {
+            $id = $sc->getParameter('id');
+            $class = $sc->getParameter('class');
+	    $caption = $sc->getParameter('caption');
+
+            $id_output = $id ? 'id="' . $id . '" ': '';
+            $class_output = $class ? 'class="' . $class . '"' : '';
+	    $caption_output = $caption ? '<figcaption>' . $caption . '</figcaption>' : '';
+            return '<figure ' . $id_output . ' ' . $class_output . '>'.$sc->getContent(). $caption_output . '</figure>';
+        });
+    }
+}


### PR DESCRIPTION
The figure element is the currently recommended way to include
self-contained flow content such as images, charts, videos and other
visual elements. It allows for the inclusion of captions. It is used by
several css frameworks in handling images and other media, where the
classes are mainly applied to figure elements instead. Including it in
the core shortcodes plugin would be very convenient.

Signed-off-by: Gerard Salvatella <gerard.salvatella@gmail.com>