### PR TITLE
Fix for empty space in end of line

### DIFF
--- a/classes/ShortcodeManager.php
+++ b/classes/ShortcodeManager.php
@@ -199,7 +199,7 @@ class ShortcodeManager
             $valid_shortcodes = implode('|', $this->handlers->getNames());
             $regex = '/^\[\/?(?:'.$valid_shortcodes.')[^\]]*\]$/';
 
-            if (preg_match($regex, $Line['body'], $matches)) {
+            if (preg_match($regex, trim($Line['body']), $matches)) {
                 $Block = array(
                     'markup' => $Line['body'],
                 );


### PR DESCRIPTION
When there's an empty space in the opening or closing line of a shortcode, the result will not be rendered.

[columns] 
text to be in columns here
[/columns] 

won't work, because there's a space after [columns]

By trimming the line in the preg_match, we make sure that any unexpected empty space is removed.