### PR TITLE
Concatenate 'px' to $size only if $size is numeric

### DIFF
--- a/shortcodes/SizeShortcode.php
+++ b/shortcodes/SizeShortcode.php
@@ -9,7 +9,8 @@ class SizeShortcode extends Shortcode
     {
         $this->shortcode->getHandlers()->add('size', function(ShortcodeInterface $sc) {
             $size = $sc->getParameter('size', $sc->getBbCode());
-            return '<span style="font-size: '.$size.'px;">'.$sc->getContent().'</span>';
+            if ( is_numeric($size) ) { $size = $size.'px' ; }
+            return '<span style="font-size: '.$size.';">'.$sc->getContent().'</span>';
         });
     }
 }


### PR DESCRIPTION
Non-numeric values of size, eg 'x-large', get passed through without alteration