### PR TITLE
Add support for Font Awesome duotone icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,8 @@ Genie dahin einem ein gib geben allen.
 
 [fa icon=fa-camera-retro /] Explicit format
 
+[fa icon=fa-grav extras=fab /] Font Awesome 5 format
+
 [fa icon=fa-camera-retro extras=fa-4x /] Explicit format with extras - [See FontAwesome Examples](https://fortawesome.github.io/Font-Awesome/examples/)
 
 [fa icon=fa-circle-o-notch extras=fa-spin,fa-3x,fa-fw,margin-bottom /] The full monty! - [See FontAwesome Examples](https://fortawesome.github.io/Font-Awesome/examples/)

--- a/classes/shortcodes/FontAwesomeShortcode.php
+++ b/classes/shortcodes/FontAwesomeShortcode.php
@@ -14,7 +14,7 @@ class FontAwesomeShortcode extends Shortcode
                 $this->shortcode->addAssets('css', $this->config->get('plugins.shortcode-core.fontawesome.url'));
             }
             if ($this->config->get('plugins.shortcode-core.fontawesome.v5', false)) {
-                $v5classes = ['fab', 'fal', 'fas', 'far'];
+                $v5classes = ['fab', 'fal', 'fas', 'far', 'fad'];
             } else {
                 $v5classes = [];
             }


### PR DESCRIPTION
This PR adds support for duotone icons in Font Awesome via `extras=fad`.

Fixes #80.