### PR TITLE
Support for asset collections and arrays

### DIFF
--- a/classes/plugin/ShortcodeManager.php
+++ b/classes/plugin/ShortcodeManager.php
@@ -64,18 +64,23 @@ class ShortcodeManager
      * add CSS and JS assets to the Manager so that they can be saved to cache
      * for subsequent cached pages
      *
-     * @param mixed $action the type of asset, JS or CSS, or an array of stuff
+     * @param mixed $actionOrAsset the type of asset (JS or CSS) or, if the second parameter is omitted,
+     *      a collection or an array of asset.
      * @param string $asset the asset path in question
      */
-    public function addAssets($action, $asset)
+    public function addAssets($actionOrAsset, $asset = null)
     {
-        if (is_array($action)) {
-            $this->assets['add'] [] = $action;
+        if ($asset == null) {
+            if (is_array($actionOrAsset)) {
+                $this->assets[''] = array_merge($this->assets[''] ?? array(), $actionOrAsset);
+            } else {
+                $this->assets[''] [] = $actionOrAsset;
+            }
         } else {
-            if (isset($this->assets[$action]) && in_array($asset, $this->assets[$action], true)) {
+            if (isset($this->assets[$actionOrAsset]) && in_array($asset, $this->assets[$actionOrAsset], true)) {
                 return;
             }
-            $this->assets[$action] [] = $asset;
+            $this->assets[$actionOrAsset] [] = $asset;
         }
     }
 


### PR DESCRIPTION
This PR adds support for collections (named resources) of assets and arrays.

I did not really get what the previous code was supposed to do when the first parameter was an array. It wouldn't work since the actual call on Grav's asset instance would be `addAdd` ( https://github.com/getgrav/grav-plugin-shortcode-core/blob/develop/shortcode-core.php#L194 ).

While previously I had to do this:
```php
            $this->shortcode->addAssets('js', 'plugin://a-plugin/assets/a-js.js');
            $this->shortcode->addAssets('css', 'plugin://a-plugin/assets/a-css.css');
```

With no possibility of overloading those assets. I can now do:

```php
// in a plugin
    public function onAssetsInitialized()
    {
        $assets = $this->grav['assets'];

        $assets->registerCollection('a-collection', [
            'plugin://a-plugin/assets/a-js.js',
            'plugin://a-plugin/assets/a-css.css'
        ]);
    }

// in the shortcode
            $this->shortcode->addAssets('a-collection');
```

It also fixes the possibility of adding assets by array or string, similar to what Grav's Asset `add()` method does ( https://learn.getgrav.org/16/api#class-grav-common-assets )
