### PR TITLE
Configuration to exclude default shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ active: true
 active_admin: true
 admin_pages_only: true
 parser: regex
+include_default_shortcodes: true
 custom_shortcodes:
 load_fontawesome: false
 ```
@@ -54,7 +55,8 @@ load_fontawesome: false
 * `active: true|false` toggles if shortcodes will be enabled site-wide or not
 * `active_admin: true|false` toggles if shortcodes will be processed in the admin plugin
 * `admin_pages_only: true|false` toggles if admin should only process shortcodes for Grav pages
-* `parser: wordpress|regex|regular` let's you configure the parser to use.
+* `parser: wordpress|regex|regular` let's you configure the parser to use
+* `include_default_shortcodes: true|false` toggle the inclusion of shortcodes provided by this plugin
 * `custom_shortcodes:` the path to a directory where you can put your custom shortcodes (e.g. `/user/custom/shortcodes`)
 * `load_fontawesome: true|false` toggles if the fontawesome icon library should be loaded or not
 

--- a/shortcode-core.php
+++ b/shortcode-core.php
@@ -208,7 +208,10 @@ class ShortcodeCorePlugin extends Plugin
      */
     public function onShortcodeHandlers()
     {
-        $this->shortcodes->registerAllShortcodes(__DIR__ . '/classes/shortcodes', ['ignore' => ['Shortcode', 'ShortcodeObject']]);
+        $include_default_shortcodes = $this->config->get('plugins.shortcode-core.include_default_shortcodes', true);
+        if ($include_default_shortcodes) {
+            $this->shortcodes->registerAllShortcodes(__DIR__ . '/classes/shortcodes', ['ignore' => ['Shortcode', 'ShortcodeObject']]);
+        }
 
         // Add custom shortcodes directory if provided
         $custom_shortcodes = $this->config->get('plugins.shortcode-core.custom_shortcodes');

--- a/shortcode-core.yaml
+++ b/shortcode-core.yaml
@@ -3,6 +3,7 @@ active: true
 active_admin: true
 admin_pages_only: true
 parser: regular
+include_default_shortcodes: true
 custom_shortcodes:
 fontawesome:
   load: true


### PR DESCRIPTION
This lets the user decide if the default shortcodes provided with this plugin should be included or not.

I feel that a plugin named `shortcode-core` should not include any by itself and this is a poor-man's substitute for this.