### PR TITLE
Add processShortcodesRaw($str) using raw_handlers

### DIFF
--- a/classes/plugin/ShortcodeManager.php
+++ b/classes/plugin/ShortcodeManager.php
@@ -283,14 +283,25 @@ class ShortcodeManager
      * For example when used by Twig directly
      *
      * @param $str
+     * @param null $handlers
      * @return string
      */
-    public function processShortcodes($str)
+    public function processShortcodes($str, $handlers = null)
     {
         $parser = $this->getParser($this->config->get('parser'));
-        $processor = new Processor(new $parser(new CommonSyntax()), $this->handlers);
+
+        if (!$handlers) {
+            $handlers = $this->handlers;
+        }
+
+        $processor = new Processor(new $parser(new CommonSyntax()), $handlers);
 
         return $processor->process($str);
+    }
+
+    public function processShortcodesRaw($str)
+    {
+        return $this->processShortcodes($str, $this->raw_handlers);
     }
 
     /**


### PR DESCRIPTION
Method `ShortcodeManager::processContent()` has a counterpart to process shortcodes using raw handlers. Method `ShortcodeManager::processShortcodes($str)` does not have a counterpart to process shortcodes strings using raw handlers.

I missed the ability to run a shortcode string using raw handlers during Unit testing of shortcodes.

This PR adds the missing method `ShortodeManager::processShortcodesRaw($str)` which processes shortcodes using the raw handlers.

Not sure if it should be `processShortcodesRaw($str)` or `processRawShortcodes($str)` though...